### PR TITLE
Fix: Respect JWT expiration in frontend token handling

### DIFF
--- a/learnmate-frontend/src/services/tokenService.js
+++ b/learnmate-frontend/src/services/tokenService.js
@@ -22,9 +22,20 @@ class TokenService {
   }
 
   // Check if token is expired (DEMO MODE: ALWAYS FALSE)
-  isTokenExpired(token) {
-    return false;
+  import jwtDecode from "jwt-decode";
+
+isTokenExpired(token) {
+  if (!token) return true;
+
+  try {
+    const decoded = jwtDecode(token);
+    const currentTime = Date.now() / 1000; // seconds
+    return decoded.exp < currentTime;
+  } catch {
+    // Invalid or malformed token → treat as expired
+    return true;
   }
+}
 
   // Get token expiry time
   getTokenExpiryTime(token) {


### PR DESCRIPTION
## Problem
The frontend token handling logic permanently disabled token expiration
checks by hardcoding `isTokenExpired()` to always return `false`.

This caused the client to treat expired JWTs as valid, diverging from
backend-enforced authorization and refresh semantics.

## Solution
- Removed demo-mode token expiration logic
- Implemented proper JWT expiration validation using the `exp` claim
- Ensured expired or invalid tokens are correctly detected on the client

## Impact
- Frontend session state now aligns with backend security guarantees
- Prevents stale authentication states
- Enables correct logout / refresh behavior

This change fixes a frontend-backend security mismatch.
