### PR TITLE
fix: separate frontend CI and document correctness-only principle (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,6 @@ jobs:
     - run: npm ci
     # - run: npm test # Uncomment when tests are added
 
-  frontend-build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./learnmate-frontend
-    strategy:
-      matrix:
-        node-version: [18.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
 
   ai-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,23 @@
+name: Frontend Build
+
+on:
+  pull_request:
+    paths:
+      - "learnmate-frontend/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: learnmate-frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - run: npm ci
+      - run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ git checkout -b fix/issue-number-short-description
 - Address feedback promptly
 - Be patient — this is a volunteer project
 
+### 6. CI Expectations
+
+Pull requests must pass all required GitHub Actions checks (backend tests and frontend build).
+
+Preview deployments (e.g. Vercel) are non-blocking and may fail due to missing authorization. These failures do not prevent merges.
+
 ## Code Standards
 
 - **Backend**: Express.js conventions, async/await


### PR DESCRIPTION
This PR implements the correctness-only CI principle by separating frontend build validation into its own workflow and documenting CI expectations to reduce contributor friction.

Changes
Workflows
NEW: 
.github/workflows/frontend.yml
 - Dedicated workflow for frontend builds
Triggers only on changes to learnmate-frontend/**
Runs npm ci and npm run build
Uses Node 18 and ubuntu-latest
MODIFIED: 
.github/workflows/ci.yml
 - Cleaned up main CI workflow
Removed redundant frontend-build job
Retained backend-test and ai-check jobs
Documentation
UPDATED: 
CONTRIBUTING.md
Added "CI Expectations" section under contribution workflow
Explicitly states that Vercel preview failures are non-blocking
Clarifies only backend tests + frontend build are required for merge
