### PR TITLE
fix: remove duplicate OAuth callback route

### DIFF
--- a/learnmate-frontend/src/App.jsx
+++ b/learnmate-frontend/src/App.jsx
@@ -110,7 +110,7 @@ function App() {
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/oauth/callback" element={<OAuthCallback />} />
-          <Route path="/oauth/callback" element={<OAuthCallback />} />
+         
 
           {/* 📩 Newly Added Email Verification Routes */}
           <Route path="/verify-email" element={<VerifyEmail />} />


### PR DESCRIPTION
## Description## Description
This PR removes a duplicate `/oauth/callback` route definition from `App.jsx`.

The route was registered twice with the same path and component, which is redundant since React Router resolves only the first match. Removing the duplicate improves routing clarity and overall code hygiene.

## What was changed
- Removed the duplicate `/oauth/callback` route
- Kept a single, correct OAuth callback route definition

## Impact
- No user-facing behavior change
- Improves maintainability and readability
- Aligns with React Router best practices

## Related Issue
Fixes #6

## Type of Change
- [x] Bug fix (non-breaking)
- [x] Code quality improvement

